### PR TITLE
feat: vertex-claude 모델과의 api 통신 로직, 엔드포인트 구현

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -12,7 +12,8 @@
         "dotenv": "^16.4.5",
         "express": "^4.21.1",
         "firebase-admin": "^12.6.0",
-        "firebase-functions": "^6.0.1"
+        "firebase-functions": "^6.0.1",
+        "googleapis": "^144.0.0"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.12.0",
@@ -4636,6 +4637,49 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/googleapis": {
+      "version": "144.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-144.0.0.tgz",
+      "integrity": "sha512-ELcWOXtJxjPX4vsKMh+7V+jZvgPwYMlEhQFiu2sa9Qmt5veX8nwXPksOWGGN6Zk4xCiLygUyaz7xGtcMO+Onxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -8322,6 +8366,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/functions/package.json
+++ b/functions/package.json
@@ -21,7 +21,8 @@
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
     "firebase-admin": "^12.6.0",
-    "firebase-functions": "^6.0.1"
+    "firebase-functions": "^6.0.1",
+    "googleapis": "^144.0.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.12.0",

--- a/functions/src/app.ts
+++ b/functions/src/app.ts
@@ -2,6 +2,7 @@ import * as express from 'express';
 import * as cors from 'cors';
 import authRoutes from './routes/auth.routes';
 import userRoutes from './routes/user.routes';
+import vertexClaudeRoutes from './routes/vertex-claude.routes';
 
 const app = express();
 
@@ -12,6 +13,7 @@ app.use(express.json());
 // 라우트 설정
 app.use('/auth', authRoutes);
 app.use('/user', userRoutes);
+app.use('/api', vertexClaudeRoutes);
 
 // 404 에러 핸들러
 app.use((req, res) => {

--- a/functions/src/app.ts
+++ b/functions/src/app.ts
@@ -13,7 +13,7 @@ app.use(express.json());
 // 라우트 설정
 app.use('/auth', authRoutes);
 app.use('/user', userRoutes);
-app.use('/api', vertexClaudeRoutes);
+app.use('/vertex-claude', vertexClaudeRoutes);
 
 // 404 에러 핸들러
 app.use((req, res) => {

--- a/functions/src/data/prompts/vertex-claude.prompt.ts
+++ b/functions/src/data/prompts/vertex-claude.prompt.ts
@@ -1,0 +1,52 @@
+export interface VertexClaudePrompt {
+  system: {
+    input: string;
+    response: string;
+  };
+}
+/* eslint-disable max-len */
+export const vertexClaudePrompt: VertexClaudePrompt = {
+  system: {
+    input: `# System Setting
+  
+  You are now an AI assistant specializing in tarot card interpretation. Your role is to provide clear and accurate tarot \
+  readings based on user input and the cards drawn by the user. Below are the key instructions for your behavior:
+  
+  ## Role
+  - **Tarot Expert:** Your primary function is to interpret tarot cards, offering meaningful insights, advice, and predictions \
+  based on the user's input and the cards drawn.
+    
+  ## Instructions
+  1. **Direct Answers:** 
+     - Your interpretations must be clear, direct, and actionable. Avoid vagueness or ambiguity in your responses.
+     
+  2. **Utilize Full Knowledge:**
+     - When analyzing the tarot cards, you must use not only the keywords and descriptions provided but also all of your \
+  prior knowledge to give the most appropriate interpretation.
+     
+  3. **Determine User's Intent:**
+     - The user may seek advice or predictions. Based on the user's question, determine whether they are asking for \
+  guidance or a future prediction, and tailor your response accordingly.
+  
+  ## Language Handling
+  - **Korean Input:** If the user's input is in Korean, respond in Korean without drawing attention to the language difference.
+  - **English Input:** If the input is in English, respond in English.
+  - **Consistency:** Always reply in the same language the user uses to ensure smooth communication.
+  
+  ## User-Centered Responses
+  - **User Clarity:** If the user asks unclear or open-ended questions, do your best to interpret their intent and provide \
+  guidance or predictions as needed.
+    
+  Your goal is to act as a reliable, knowledgeable tarot expert, ensuring that every reading is meaningful and directly \
+  applicable to the user's question or situation.`,
+    response: `# Request Approved
+  
+  I have received and understood the instructions. I will now operate as an AI assistant specializing in tarot card \
+  interpretation, providing clear, direct, and actionable insights based on the user's input and the cards drawn. I will \
+  use my full knowledge of tarot, along with the provided card information, to offer guidance or predictions as appropriate \
+  to the user's request. Responses will be given in the same language used by the user, whether in Korean or English.
+  
+  I am ready to assist with tarot readings.`,
+  },
+};
+/* eslint-enable max-len */

--- a/functions/src/routes/vertex-claude.routes.ts
+++ b/functions/src/routes/vertex-claude.routes.ts
@@ -1,0 +1,34 @@
+import { Router } from 'express';
+import type { RequestHandler } from 'express';
+import { VertexClaudeService } from '../services/vertex-claude.service';
+import { authMiddleware } from '../middleware/auth.middleware';
+
+const router = Router();
+const vertexService = VertexClaudeService.getInstance();
+
+interface ReadingRequest {
+  query: string;
+}
+
+const handleReading: RequestHandler = async (req, res) => {
+  try {
+    const { query } = req.body as ReadingRequest;
+
+    if (!query) {
+      return res.status(400).json({ error: '질문이 누락되었습니다.' });
+    }
+
+    const result = await vertexService.generateReading(query);
+    return res.json(result);
+  } catch (error) {
+    console.error('Vertex Claude error:', error);
+    return res.status(500).json({
+      error: '처리 중 오류가 발생했습니다.',
+      details: error instanceof Error ? error.message : '알 수 없는 오류'
+    });
+  }
+};
+
+router.post('/vertex-claude', authMiddleware, handleReading);
+
+export default router;

--- a/functions/src/routes/vertex-claude.routes.ts
+++ b/functions/src/routes/vertex-claude.routes.ts
@@ -29,6 +29,6 @@ const handleReading: RequestHandler = async (req, res) => {
   }
 };
 
-router.post('/vertex-claude', authMiddleware, handleReading);
+router.post('/', authMiddleware, handleReading);
 
 export default router;

--- a/functions/src/services/vertex-claude.service.ts
+++ b/functions/src/services/vertex-claude.service.ts
@@ -1,0 +1,111 @@
+import { GoogleAuth, OAuth2Client } from 'google-auth-library';
+import axios from 'axios';
+import { vertexClaudePrompt } from '../data/prompts/vertex-claude.prompt';
+import { getServiceAccountKey } from '../utils/loadSecrets';
+
+export class VertexClaudeService {
+  private static instance: VertexClaudeService;
+  private accessToken: string | null = null;
+  private tokenExpiry: Date | null = null;
+
+  private constructor() {}
+
+  public static getInstance(): VertexClaudeService {
+    if (!this.instance) {
+      this.instance = new VertexClaudeService();
+    }
+    return this.instance;
+  }
+
+  private async getAccessToken(): Promise<string> {
+    if (this.accessToken && this.tokenExpiry && this.tokenExpiry > new Date()) {
+      return this.accessToken;
+    }
+
+    const serviceAccountKey = await getServiceAccountKey();
+    const credentials = JSON.parse(serviceAccountKey);
+
+    const auth = new GoogleAuth({
+      credentials,
+      scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+    });
+
+    const client = await auth.getClient();
+    const response = await client.getAccessToken();
+
+    if (!response.token) {
+      throw new Error('Failed to get access token');
+    }
+
+    // OAuth2Client로 타입 캐스팅
+    const oAuth2Client = client as OAuth2Client;
+    const expiryDate = oAuth2Client.credentials.expiry_date;
+
+    this.accessToken = response.token;
+    this.tokenExpiry = expiryDate? new Date(expiryDate): new Date(Date.now() + 3600000);
+
+    return this.accessToken;
+  }
+
+  private createVertexClient(token: string) {
+    return axios.create({
+      baseURL: 'https://us-east5-aiplatform.googleapis.com',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+
+  private getEndpointPath(): string {
+    return '/v1/projects/moonstruck-1/locations/us-east5/publishers/google/models/claude-3-sonnet-20240229:rawPredict';
+  }
+
+  async generateReading(formattedQuery: string): Promise<any> {
+    try {
+      const token = await this.getAccessToken();
+      const client = this.createVertexClient(token);
+
+      const response = await client.post(this.getEndpointPath(), {
+        anthropic_version: 'vertex-2023-10-16',
+        messages: [
+          { role: 'user', content: vertexClaudePrompt.system.input },
+          { role: 'assistant', content: vertexClaudePrompt.system.response },
+          { role: 'user', content: formattedQuery },
+        ],
+        max_tokens: 1024,
+        temperature: 0.7,
+      });
+
+      return response.data;
+    } catch (error) {
+      console.error('Vertex Claude API Error:', error);
+      throw this.handleError(error);
+    }
+  }
+
+  private handleError(error: any): Error {
+    if (axios.isAxiosError(error)) {
+      const statusCode = error.response?.status;
+      const errorMessage =
+        error.response?.data?.error?.message || error.message;
+
+      switch (statusCode) {
+      case 401:
+        return new Error(
+          '인증 오류가 발생했습니다. 서비스 계정 키를 확인해주세요.'
+        );
+      case 403:
+        return new Error(
+          '권한이 없습니다. 서비스 계정의 권한을 확인해주세요.'
+        );
+      case 429:
+        return new Error('요청이 너무 많습니다. 잠시 후 다시 시도해주세요.');
+      default:
+        return new Error(`API 오류: ${errorMessage}`);
+      }
+    }
+
+    return error instanceof Error ? error : new Error('알 수 없는 오류가 발생했습니다.');
+  }
+}

--- a/functions/src/services/vertex-claude.service.ts
+++ b/functions/src/services/vertex-claude.service.ts
@@ -61,25 +61,39 @@ export class VertexClaudeService {
     return '/v1/projects/moonstruck-1/locations/us-east5/publishers/google/models/claude-3-sonnet-20240229:rawPredict';
   }
 
-  async generateReading(formattedQuery: string): Promise<any> {
+  async generateReading(query: string): Promise<any> {
     try {
       const token = await this.getAccessToken();
       const client = this.createVertexClient(token);
 
-      const response = await client.post(this.getEndpointPath(), {
-        anthropic_version: 'vertex-2023-10-16',
-        messages: [
-          { role: 'user', content: vertexClaudePrompt.system.input },
-          { role: 'assistant', content: vertexClaudePrompt.system.response },
-          { role: 'user', content: formattedQuery },
-        ],
-        max_tokens: 1024,
-        temperature: 0.7,
-      });
+      const response = await client.post(
+        this.getEndpointPath(),
+        {
+          anthropic_version: 'vertex-2023-10-16',
+          messages: [
+            { role: 'user', content: vertexClaudePrompt.system.input },
+            { role: 'assistant', content: vertexClaudePrompt.system.response },
+            { role: 'user', content: query },
+          ],
+          max_tokens: 1024,
+          temperature: 0.7,
+        }
+      );
 
       return response.data;
     } catch (error) {
-      console.error('Vertex Claude API Error:', error);
+      if (axios.isAxiosError(error)) {
+        console.error('Vertex API Detailed Error:', {
+          status: error.response?.status,
+          statusText: error.response?.statusText,
+          data: error.response?.data,
+          config: {
+            url: error.config?.url,
+            headers: error.config?.headers,
+            method: error.config?.method,
+          }
+        });
+      }
       throw this.handleError(error);
     }
   }

--- a/functions/src/services/vertex-claude.service.ts
+++ b/functions/src/services/vertex-claude.service.ts
@@ -1,7 +1,7 @@
 import { GoogleAuth, OAuth2Client } from 'google-auth-library';
 import axios from 'axios';
 import { vertexClaudePrompt } from '../data/prompts/vertex-claude.prompt';
-import { getServiceAccountKey } from '../utils/loadSecrets';
+import { getVertexServiceAccountKey } from '../utils/loadSecrets';
 
 export class VertexClaudeService {
   private static instance: VertexClaudeService;
@@ -22,7 +22,7 @@ export class VertexClaudeService {
       return this.accessToken;
     }
 
-    const serviceAccountKey = await getServiceAccountKey();
+    const serviceAccountKey = await getVertexServiceAccountKey();
     const credentials = JSON.parse(serviceAccountKey);
 
     const auth = new GoogleAuth({
@@ -56,9 +56,9 @@ export class VertexClaudeService {
       },
     });
   }
-
+  /* eslint-disable max-len */
   private getEndpointPath(): string {
-    return '/v1/projects/moonstruck-1/locations/us-east5/publishers/google/models/claude-3-sonnet-20240229:rawPredict';
+    return '/v1/projects/moonstruck-1/locations/us-east5/publishers/anthropic/models/claude-3-5-sonnet@20240620:rawPredict';
   }
 
   async generateReading(query: string): Promise<any> {

--- a/functions/src/utils/loadSecrets.ts
+++ b/functions/src/utils/loadSecrets.ts
@@ -35,3 +35,7 @@ export async function getKakaoRestApiKey(): Promise<string> {
 export async function getServiceAccountKey(): Promise<string> {
   return getSecret('SERVICE_ACCOUNT_KEY');
 }
+
+export async function getVertexServiceAccountKey(): Promise<string> {
+  return getSecret('VERTEX_AI_SERVICE_ACCOUNT_KEY');
+}


### PR DESCRIPTION
기존에 클라이언트에서 관리하던 api 통신 로직을 서버리스로 옮김
- 프롬프트 또한 클라이언트보단 서버에서 관리해야 한다고 판단하여 함께 옮겨옴
- 서비스 계정 키에 권한이 없다고 뜨는 사소한 문제가 있었으나 매우 멍청하게도 파이어베이스 프로젝트를 돌리는 구글 계정(thewronghand777)의 서비스 계정 키로 Vertex AI에 접근하려 하고 있었던 것으로 밝혀짐. Vertex AI를 돌리는 구글 계정(the2ndString95)의 서비스 키를 받아와서 별도의 비밀을 생성하고 이걸로 요청하니까 매우 잘 됨.
- 별도의 모델을 추가하기 쉽도록 엔드포인트명은 vertex-claude로 함.