### PR TITLE
feat: 프롬프트 포매팅 로직 추가, 스프레드별 프롬프트 조각 추가, 기본 프롬프트 구체화

### DIFF
--- a/functions/eslint.config.js
+++ b/functions/eslint.config.js
@@ -33,7 +33,7 @@ module.exports = [
         },
       ],
       'no-unused-vars': 'off',
-      indent: ['error', 2],
+      indent: ['error', 2, { SwitchCase: 1 }],
       'new-cap': 'off',
       'max-len': ['error', { code: 120 }],
       'quote-props': [

--- a/functions/src/data/prompts/spread.prompt.ts
+++ b/functions/src/data/prompts/spread.prompt.ts
@@ -1,0 +1,24 @@
+/* eslint-disable max-len */
+import { SpreadType } from '../../types/spread';
+
+export interface SpreadPrompt {
+  description: string;
+}
+
+export const spreadPrompts: { [key in SpreadType]: SpreadPrompt } = {
+  SINGLE: {
+    description: 'A single card spread provides a direct answer or insight to a specific question or situation. As this spread relies on just one card, the interpretation should be thorough and detailed, drawing upon the card\'s symbolism, imagery, traditional meanings, and elemental associations to provide comprehensive guidance.'
+  },
+  TRIPLE_TIMELINE: {
+    description: 'The Triple Timeline spread uses three cards to explore the past, present, and future aspects of a situation, showing how events and energies flow through time.'
+  },
+  TRIPLE_CHOICE: {
+    description: 'The Triple Choice spread helps with decision-making by showing the current situation in the center card, with the left and right cards representing two different possible paths or choices.'
+  },
+  FIVE_CARD_CROSS: {
+    description: 'The Five Card Cross spread places cards in a cross pattern, with the center showing the current situation, surrounded by cards representing influences above, below, behind, and ahead.'
+  },
+  CELTIC_CROSS: {
+    description: 'The Celtic Cross is a comprehensive ten-card spread that explores multiple aspects of a situation, including past influences, future possibilities, hopes, fears, and potential outcomes.'
+  }
+};

--- a/functions/src/data/prompts/vertex-claude.prompt.ts
+++ b/functions/src/data/prompts/vertex-claude.prompt.ts
@@ -8,45 +8,56 @@ export interface VertexClaudePrompt {
 export const vertexClaudePrompt: VertexClaudePrompt = {
   system: {
     input: `# System Setting
-  
-  You are now an AI assistant specializing in tarot card interpretation. Your role is to provide clear and accurate tarot \
-  readings based on user input and the cards drawn by the user. Below are the key instructions for your behavior:
-  
-  ## Role
-  - **Tarot Expert:** Your primary function is to interpret tarot cards, offering meaningful insights, advice, and predictions \
-  based on the user's input and the cards drawn.
-    
-  ## Instructions
-  1. **Direct Answers:** 
-     - Your interpretations must be clear, direct, and actionable. Avoid vagueness or ambiguity in your responses.
-     
-  2. **Utilize Full Knowledge:**
-     - When analyzing the tarot cards, you must use not only the keywords and descriptions provided but also all of your \
-  prior knowledge to give the most appropriate interpretation.
-     
-  3. **Determine User's Intent:**
-     - The user may seek advice or predictions. Based on the user's question, determine whether they are asking for \
-  guidance or a future prediction, and tailor your response accordingly.
-  
-  ## Language Handling
-  - **Korean Input:** If the user's input is in Korean, respond in Korean without drawing attention to the language difference.
-  - **English Input:** If the input is in English, respond in English.
-  - **Consistency:** Always reply in the same language the user uses to ensure smooth communication.
-  
-  ## User-Centered Responses
-  - **User Clarity:** If the user asks unclear or open-ended questions, do your best to interpret their intent and provide \
-  guidance or predictions as needed.
-    
-  Your goal is to act as a reliable, knowledgeable tarot expert, ensuring that every reading is meaningful and directly \
-  applicable to the user's question or situation.`,
+
+You are now an AI assistant specializing in tarot card interpretation. Your role is to provide clear, direct, and symbolic tarot \
+readings based on user input and the cards drawn by the user. Below are the key instructions for your behavior:
+
+## Role
+- **Tarot Expert:** Your primary function is to interpret tarot cards, offering insightful and actionable interpretations based on \
+their symbolic meanings and the user's input.
+
+## Instructions
+1. **Symbolic and Clear Interpretations:**
+   - Interpret the cards with clarity and precision, focusing on their symbols, imagery, and deeper meanings.
+   - Avoid ambiguity. Provide interpretations that are direct and leave no room for misinterpretation.
+
+2. **Balanced Objectivity:**
+   - Do not shy away from challenging or contradicting the user's hopes or assumptions if the drawn cards suggest otherwise.
+   - Use the cards to guide the user towards a realistic and constructive perspective, even if it means offering difficult truths.
+
+3. **Output Guidelines:**
+   - Start directly with the tarot card interpretation without any introductory phrases, greetings, or filler language.
+   - Ensure that the response is concise and focused solely on the interpretation of the cards.
+
+4. **Contextual Relevance:**
+   - Tailor your interpretations to the user's input, connecting the cards' symbolic messages to their specific situation or question.
+   - When the user's question is vague, let the drawn cards steer the response while maintaining a clear and structured explanation.
+
+5. **Empathy with Honesty:**
+   - Balance directness with empathy, ensuring the user feels supported while also receiving honest, unvarnished insights.
+   - Encourage self-reflection and empowerment by presenting both challenges and opportunities highlighted by the cards.
+
+6. **Rich Symbolic Language:**
+   - Use vivid and descriptive language to convey the cards' meanings, drawing on their imagery and archetypal symbolism to deepen understanding.
+
+## Language Handling
+- **Korean Input:** If the user's input is in Korean, respond in Korean while maintaining the same clarity and symbolic depth.
+- **English Input:** If the input is in English, respond in English with equivalent directness and nuance.
+- **Consistency:** Always reply in the same language the user uses to ensure smooth communication.
+
+## User-Centered Responses
+- **Challenge Ambiguity:** If the user's question is unclear, provide a clear interpretation that addresses potential scenarios.
+- **Empowerment with Truth:** Frame interpretations in a way that empowers the user, while being unafraid to present difficult or unexpected insights.
+
+Your goal is to act as a trusted tarot expert, providing interpretations that are clear, symbolic, and directly applicable to the user's question or situation.`,
     response: `# Request Approved
-  
-  I have received and understood the instructions. I will now operate as an AI assistant specializing in tarot card \
-  interpretation, providing clear, direct, and actionable insights based on the user's input and the cards drawn. I will \
-  use my full knowledge of tarot, along with the provided card information, to offer guidance or predictions as appropriate \
-  to the user's request. Responses will be given in the same language used by the user, whether in Korean or English.
-  
-  I am ready to assist with tarot readings.`,
+
+I have received and understood the instructions. I will now operate as an AI assistant specializing in tarot card \
+interpretation, focusing on clear, symbolic, and direct readings. I will not include any introductory phrases or greetings \
+and will provide interpretations that begin immediately with the relevant analysis of the drawn cards. My interpretations \
+will balance vivid symbolic language with precise and actionable guidance, ensuring the user's understanding is deep and \
+meaningful. Responses will be given in the same language used by the user, whether in Korean or English.
+
+I am ready to assist with tarot readings.`,
   },
 };
-/* eslint-enable max-len */

--- a/functions/src/routes/vertex-claude.routes.ts
+++ b/functions/src/routes/vertex-claude.routes.ts
@@ -2,23 +2,27 @@ import { Router } from 'express';
 import type { RequestHandler } from 'express';
 import { VertexClaudeService } from '../services/vertex-claude.service';
 import { authMiddleware } from '../middleware/auth.middleware';
+import type { DrawnTarotCard } from '../types/tarot';
+import type { SpreadType } from '../types/spread';
 
 const router = Router();
 const vertexService = VertexClaudeService.getInstance();
 
 interface ReadingRequest {
-  query: string;
+  userInput: string;
+  cards: DrawnTarotCard[];
+  spreadType: SpreadType;
 }
 
 const handleReading: RequestHandler = async (req, res) => {
   try {
-    const { query } = req.body as ReadingRequest;
+    const { userInput, cards, spreadType } = req.body as ReadingRequest;
 
-    if (!query) {
-      return res.status(400).json({ error: '질문이 누락되었습니다.' });
+    if (!userInput || !cards || !spreadType) {
+      return res.status(400).json({ error: '필수 정보가 누락되었습니다.' });
     }
 
-    const result = await vertexService.generateReading(query);
+    const result = await vertexService.generateReading(userInput, cards, spreadType);
     return res.json(result);
   } catch (error) {
     console.error('Vertex Claude error:', error);

--- a/functions/src/services/vertex-claude.service.ts
+++ b/functions/src/services/vertex-claude.service.ts
@@ -2,6 +2,9 @@ import { GoogleAuth, OAuth2Client } from 'google-auth-library';
 import axios from 'axios';
 import { vertexClaudePrompt } from '../data/prompts/vertex-claude.prompt';
 import { getVertexServiceAccountKey } from '../utils/loadSecrets';
+import { formatReadingPrompt } from '../utils/promptFormatter';
+import type { DrawnTarotCard } from '../types/tarot';
+import type { SpreadType } from '../types/spread';
 
 export class VertexClaudeService {
   private static instance: VertexClaudeService;
@@ -37,12 +40,11 @@ export class VertexClaudeService {
       throw new Error('Failed to get access token');
     }
 
-    // OAuth2Client로 타입 캐스팅
     const oAuth2Client = client as OAuth2Client;
     const expiryDate = oAuth2Client.credentials.expiry_date;
 
     this.accessToken = response.token;
-    this.tokenExpiry = expiryDate? new Date(expiryDate): new Date(Date.now() + 3600000);
+    this.tokenExpiry = expiryDate ? new Date(expiryDate) : new Date(Date.now() + 3600000);
 
     return this.accessToken;
   }
@@ -61,10 +63,15 @@ export class VertexClaudeService {
     return '/v1/projects/moonstruck-1/locations/us-east5/publishers/anthropic/models/claude-3-5-sonnet@20240620:rawPredict';
   }
 
-  async generateReading(query: string): Promise<any> {
+  async generateReading(
+    userInput: string,
+    cards: DrawnTarotCard[],
+    spreadType: SpreadType
+  ): Promise<any> {
     try {
       const token = await this.getAccessToken();
       const client = this.createVertexClient(token);
+      const formattedPrompt = formatReadingPrompt(userInput, cards, spreadType);
 
       const response = await client.post(
         this.getEndpointPath(),
@@ -73,7 +80,7 @@ export class VertexClaudeService {
           messages: [
             { role: 'user', content: vertexClaudePrompt.system.input },
             { role: 'assistant', content: vertexClaudePrompt.system.response },
-            { role: 'user', content: query },
+            { role: 'user', content: formattedPrompt },
           ],
           max_tokens: 1024,
           temperature: 0.7,
@@ -101,25 +108,19 @@ export class VertexClaudeService {
   private handleError(error: any): Error {
     if (axios.isAxiosError(error)) {
       const statusCode = error.response?.status;
-      const errorMessage =
-        error.response?.data?.error?.message || error.message;
+      const errorMessage = error.response?.data?.error?.message || error.message;
 
       switch (statusCode) {
-      case 401:
-        return new Error(
-          '인증 오류가 발생했습니다. 서비스 계정 키를 확인해주세요.'
-        );
-      case 403:
-        return new Error(
-          '권한이 없습니다. 서비스 계정의 권한을 확인해주세요.'
-        );
-      case 429:
-        return new Error('요청이 너무 많습니다. 잠시 후 다시 시도해주세요.');
-      default:
-        return new Error(`API 오류: ${errorMessage}`);
+        case 401:
+          return new Error('인증 오류가 발생했습니다. 서비스 계정 키를 확인해주세요.');
+        case 403:
+          return new Error('권한이 없습니다. 서비스 계정의 권한을 확인해주세요.');
+        case 429:
+          return new Error('요청이 너무 많습니다. 잠시 후 다시 시도해주세요.');
+        default:
+          return new Error(`API 오류: ${errorMessage}`);
       }
     }
-
     return error instanceof Error ? error : new Error('알 수 없는 오류가 발생했습니다.');
   }
 }

--- a/functions/src/types/spread.ts
+++ b/functions/src/types/spread.ts
@@ -1,0 +1,6 @@
+export type SpreadType =
+  | 'SINGLE'
+  | 'TRIPLE_TIMELINE'
+  | 'TRIPLE_CHOICE'
+  | 'FIVE_CARD_CROSS'
+  | 'CELTIC_CROSS';

--- a/functions/src/utils/promptFormatter.ts
+++ b/functions/src/utils/promptFormatter.ts
@@ -1,0 +1,54 @@
+import type { DrawnTarotCard } from '../types/tarot';
+import type { SpreadType } from '../types/spread';
+import { spreadPrompts } from '../data/prompts/spread.prompt';
+
+function formatSpreadLayout(cards: DrawnTarotCard[], spreadType: SpreadType): string {
+  switch (spreadType) {
+    case 'SINGLE':
+      return `뽑힌 카드:\n${cards[0]}`;
+
+    case 'TRIPLE_CHOICE':
+      return `첫 번째 카드(중앙, 현재 상황을 나타냄):
+${cards[0]}
+
+두 번째 카드(왼쪽에 위치, 첫번째 선택지를 나타냄):
+${cards[1]}
+
+세 번째 카드(오른쪽에 위치, 두번째 선택지를 나타냄):
+${cards[2]}`;
+
+    case 'TRIPLE_TIMELINE':
+      return `첫 번째 카드(과거를 나타냄):
+${cards[0]}
+
+두 번째 카드(현재를 나타냄):
+${cards[1]}
+
+세 번째 카드(미래를 나타냄):
+${cards[2]}`;
+
+    default:
+      return cards.map((card, index) =>
+        `${index + 1}번째 카드:\n${card}`
+      ).join('\n\n');
+  }
+}
+
+export function formatReadingPrompt(
+  userInput: string,
+  cards: DrawnTarotCard[],
+  spreadType: SpreadType
+): string {
+  const spreadPrompt = spreadPrompts[spreadType];
+
+  return `# Spread Information
+${spreadPrompt.description}
+
+# Card Layout
+${formatSpreadLayout(cards, spreadType)}
+
+# User Question
+${userInput}
+
+Please interpret these tarot cards based on the spread layout and the user's question.`;
+}

--- a/functions/src/utils/promptFormatter.ts
+++ b/functions/src/utils/promptFormatter.ts
@@ -5,31 +5,31 @@ import { spreadPrompts } from '../data/prompts/spread.prompt';
 function formatSpreadLayout(cards: DrawnTarotCard[], spreadType: SpreadType): string {
   switch (spreadType) {
     case 'SINGLE':
-      return `뽑힌 카드:\n${cards[0]}`;
+      return `뽑힌 카드:\n${JSON.stringify(cards[0], null, 2)}`;
 
     case 'TRIPLE_CHOICE':
       return `첫 번째 카드(중앙, 현재 상황을 나타냄):
-${cards[0]}
+${JSON.stringify(cards[0], null, 2)}
 
 두 번째 카드(왼쪽에 위치, 첫번째 선택지를 나타냄):
-${cards[1]}
+${JSON.stringify(cards[1], null, 2)}
 
 세 번째 카드(오른쪽에 위치, 두번째 선택지를 나타냄):
-${cards[2]}`;
+${JSON.stringify(cards[2], null, 2)}`;
 
     case 'TRIPLE_TIMELINE':
       return `첫 번째 카드(과거를 나타냄):
-${cards[0]}
+${JSON.stringify(cards[0], null, 2)}
 
 두 번째 카드(현재를 나타냄):
-${cards[1]}
+${JSON.stringify(cards[1], null, 2)}
 
 세 번째 카드(미래를 나타냄):
-${cards[2]}`;
+${JSON.stringify(cards[2], null, 2)}`;
 
     default:
       return cards.map((card, index) =>
-        `${index + 1}번째 카드:\n${card}`
+        `${index + 1}번째 카드:\n${JSON.stringify(card, null, 2)}`
       ).join('\n\n');
   }
 }


### PR DESCRIPTION
- 클라이언트로부터 이관된 포매팅 로직을 구현: 받은 정보(유저 입력, 스프레드 타입, 뽑힌 카드)를 기반으로 포매팅하여 적절한 형태의 프롬프트로 바꿈.
- 트리플-양자택일, 트리플-타임라인의 프롬프트 조각 작성, 파이브 카드 크로스와 켈틱 크로스의 경우에도 적용 필요
- 기본 프롬프트의 내용을 구체화하여 넘겨받은 정보를 단순히 나열하는 대신 비유와 상징을 적극적으로 해석하도록 수정