### PR TITLE
feat: DB 스키마에 spreadType 필드 추가

### DIFF
--- a/functions/src/routes/question-reading.routes.ts
+++ b/functions/src/routes/question-reading.routes.ts
@@ -5,12 +5,12 @@ const router = Router();
 
 router.post('/save', async (req: Request, res: Response): Promise<void> => {
   try {
-    const { question, cards, interpretation } = req.body;
+    const { question, cards, interpretation, spreadType } = req.body;
 
-    if (!question || !cards || !interpretation) {
+    if (!question || !cards || !interpretation || !spreadType) {
       res.status(400).json({
         error: 'Missing required fields',
-        details: 'Question, cards, and interpretation are required'
+        details: 'Question, cards, interpretation, and spreadType are required'
       });
       return;
     }
@@ -18,7 +18,8 @@ router.post('/save', async (req: Request, res: Response): Promise<void> => {
     const readingId = await QuestionReadingRepositoryService.saveReading({
       question,
       cards,
-      interpretation
+      interpretation,
+      spreadType
     });
 
     res.json({ readingId });

--- a/functions/src/types/tarot.ts
+++ b/functions/src/types/tarot.ts
@@ -1,3 +1,5 @@
+import { SpreadType } from './spread';
+
 export interface DrawnTarotCard {
     id: number;
     name: {
@@ -18,10 +20,12 @@ export interface TarotReading {
   cards: DrawnTarotCard[];
   interpretation: string;
   createdAt: string;
+  spreadType: SpreadType;
 }
 
 export interface SaveTarotReadingRequest {
   question: string;
   cards: DrawnTarotCard[];
   interpretation: string;
+  spreadType: SpreadType;
 }


### PR DESCRIPTION
DB 스키마가 기존의 스펙변경(spreadType을 정의하고, reading에 필드로 포함하기)을 반영하지 못해 DB에 reading 정보가 저장될 때 spreadType이 누락되는 문제가 있어 백엔드 단에서 타입 정의를 추가하고, 클라이언트에서 보낸 정보를 제대로 받아와 DB에 저장하도록 수정함