### PR TITLE
feat: 클라이언트의 SPREAD_INFO 정보를 활용한 프롬프트 포매팅 개선, 에러 정보 전달 추가

### DIFF
--- a/functions/src/data/prompts/spread.prompt.ts
+++ b/functions/src/data/prompts/spread.prompt.ts
@@ -10,10 +10,10 @@ export const spreadPrompts: { [key in SpreadType]: SpreadPrompt } = {
     description: 'A single card spread provides a direct answer or insight to a specific question or situation. As this spread relies on just one card, the interpretation should be thorough and detailed, drawing upon the card\'s symbolism, imagery, traditional meanings, and elemental associations to provide comprehensive guidance.'
   },
   TRIPLE_TIMELINE: {
-    description: 'The Triple Timeline spread uses three cards to explore the past, present, and future aspects of a situation, showing how events and energies flow through time.'
+    description: 'The Triple Timeline(트리플 - 타임라인) spread uses three cards to explore the past, present, and future aspects of a situation, showing how events and energies flow through time.'
   },
   TRIPLE_CHOICE: {
-    description: 'The Triple Choice spread helps with decision-making by showing the current situation in the center card, with the left and right cards representing two different possible paths or choices.'
+    description: 'The Triple Choice(트리플 - 양자택일) spread helps with decision-making by showing the current situation in the center card, with the left and right cards representing two different possible paths or choices.'
   },
   FIVE_CARD_CROSS: {
     description: 'The Five Card Cross spread places cards in a cross pattern, with the center showing the current situation, surrounded by cards representing influences above, below, behind, and ahead.'

--- a/functions/src/routes/vertex-claude.routes.ts
+++ b/functions/src/routes/vertex-claude.routes.ts
@@ -3,7 +3,7 @@ import type { RequestHandler } from 'express';
 import { VertexClaudeService } from '../services/vertex-claude.service';
 import { authMiddleware } from '../middleware/auth.middleware';
 import type { DrawnTarotCard } from '../types/tarot';
-import type { SpreadType } from '../types/spread';
+import type { SpreadInfo } from '../types/spread';
 
 const router = Router();
 const vertexService = VertexClaudeService.getInstance();
@@ -11,24 +11,40 @@ const vertexService = VertexClaudeService.getInstance();
 interface ReadingRequest {
   userInput: string;
   cards: DrawnTarotCard[];
-  spreadType: SpreadType;
+  spreadInfo: SpreadInfo;
 }
 
 const handleReading: RequestHandler = async (req, res) => {
   try {
-    const { userInput, cards, spreadType } = req.body as ReadingRequest;
+    const { userInput, cards, spreadInfo } = req.body as ReadingRequest;
 
-    if (!userInput || !cards || !spreadType) {
-      return res.status(400).json({ error: '필수 정보가 누락되었습니다.' });
+    if (!userInput || !cards || !spreadInfo) {
+      return res.status(400).json({
+        error: '필수 정보가 누락되었습니다.',
+        code: 'MISSING_PARAMETERS'
+      });
     }
 
-    const result = await vertexService.generateReading(userInput, cards, spreadType);
+    const result = await vertexService.generateReading(userInput, cards, spreadInfo);
     return res.json(result);
   } catch (error) {
     console.error('Vertex Claude error:', error);
+
+    if (error instanceof Error) {
+      // Vertex API 에러인 경우
+      const statusCode = (error as any).statusCode || 500;
+      const vertexError = (error as any).vertexError;
+
+      return res.status(statusCode).json({
+        error: error.message,
+        code: 'VERTEX_API_ERROR',
+        vertexError // Vertex API의 원본 에러 정보
+      });
+    }
+
     return res.status(500).json({
-      error: '처리 중 오류가 발생했습니다.',
-      details: error instanceof Error ? error.message : '알 수 없는 오류'
+      error: '알 수 없는 오류가 발생했습니다.',
+      code: 'UNKNOWN_ERROR'
     });
   }
 };

--- a/functions/src/types/spread.ts
+++ b/functions/src/types/spread.ts
@@ -4,3 +4,10 @@ export type SpreadType =
   | 'TRIPLE_CHOICE'
   | 'FIVE_CARD_CROSS'
   | 'CELTIC_CROSS';
+
+export interface SpreadInfo {
+  type: SpreadType;
+  name: string;
+  description: string;
+  positions: string[];
+}

--- a/functions/src/utils/promptFormatter.ts
+++ b/functions/src/utils/promptFormatter.ts
@@ -1,51 +1,26 @@
 import type { DrawnTarotCard } from '../types/tarot';
-import type { SpreadType } from '../types/spread';
+import type { SpreadInfo } from '../types/spread';
 import { spreadPrompts } from '../data/prompts/spread.prompt';
 
-function formatSpreadLayout(cards: DrawnTarotCard[], spreadType: SpreadType): string {
-  switch (spreadType) {
-    case 'SINGLE':
-      return `뽑힌 카드:\n${JSON.stringify(cards[0], null, 2)}`;
-
-    case 'TRIPLE_CHOICE':
-      return `첫 번째 카드(중앙, 현재 상황을 나타냄):
-${JSON.stringify(cards[0], null, 2)}
-
-두 번째 카드(왼쪽에 위치, 첫번째 선택지를 나타냄):
-${JSON.stringify(cards[1], null, 2)}
-
-세 번째 카드(오른쪽에 위치, 두번째 선택지를 나타냄):
-${JSON.stringify(cards[2], null, 2)}`;
-
-    case 'TRIPLE_TIMELINE':
-      return `첫 번째 카드(과거를 나타냄):
-${JSON.stringify(cards[0], null, 2)}
-
-두 번째 카드(현재를 나타냄):
-${JSON.stringify(cards[1], null, 2)}
-
-세 번째 카드(미래를 나타냄):
-${JSON.stringify(cards[2], null, 2)}`;
-
-    default:
-      return cards.map((card, index) =>
-        `${index + 1}번째 카드:\n${JSON.stringify(card, null, 2)}`
-      ).join('\n\n');
-  }
+function formatSpreadLayout(cards: DrawnTarotCard[], spreadInfo: SpreadInfo): string {
+  return cards.map((card, index) =>
+    `${spreadInfo.positions[index]}:\n${JSON.stringify(card, null, 2)}`
+  ).join('\n\n');
 }
 
 export function formatReadingPrompt(
   userInput: string,
   cards: DrawnTarotCard[],
-  spreadType: SpreadType
+  spreadInfo: SpreadInfo
 ): string {
-  const spreadPrompt = spreadPrompts[spreadType];
+  const spreadPrompt = spreadPrompts[spreadInfo.type];
 
   return `# Spread Information
+${spreadInfo.name}
 ${spreadPrompt.description}
 
 # Card Layout
-${formatSpreadLayout(cards, spreadType)}
+${formatSpreadLayout(cards, spreadInfo)}
 
 # User Question
 ${userInput}


### PR DESCRIPTION
- 클라이언트에 추가한 SPREAD_INFO의 position 배열을 활용하여, '첫 번째 카드 (과거의 영향) : 소드 6'과 같이 효율적인 프롬프트 포매팅이 가능하도록 로직 수정
- 에러 정보를 클라이언트로 그대로 내려주도록 수정