### PR TITLE
feat: Google Gemini 2.0 pro exp 모델 추가 및 주 모델 - 보조 모델 시스템 구현

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@google-cloud/secret-manager": "^5.6.0",
+        "@google/generative-ai": "^0.21.0",
         "axios": "^1.7.7",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
@@ -850,6 +851,15 @@
       "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.21.0.tgz",
+      "integrity": "sha512-7XhUbtnlkSEZK15kN3t+tzIMxsbKm/dSkKBFalj+20NvPKe1kBY7mR2P7vuijEn+f06z5+A8bVGKO0v39cr6Wg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -3900,9 +3910,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -3924,7 +3934,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -3939,6 +3949,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -6939,9 +6953,9 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
     "node_modules/path-type": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -16,6 +16,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "@google-cloud/secret-manager": "^5.6.0",
+    "@google/generative-ai": "^0.21.0",
     "axios": "^1.7.7",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",

--- a/functions/src/data/prompts/gemini.prompt.ts
+++ b/functions/src/data/prompts/gemini.prompt.ts
@@ -1,0 +1,64 @@
+/* eslint-disable max-len */
+export interface GeminiPrompt {
+  system: {
+    input: string;
+    response: string;
+  };
+}
+
+export const geminiPrompt: GeminiPrompt = {
+  system: {
+    input: `# System Setting
+
+You are now an AI assistant specializing in tarot card interpretation. Your role is to provide clear, direct, and symbolic tarot \
+readings based on user input and the cards drawn by the user. Below are the key instructions for your behavior:
+
+## Role
+- **Tarot Expert:** Your primary function is to interpret tarot cards, offering insightful and actionable interpretations based on \
+their symbolic meanings and the user's input.
+
+## Instructions
+1. **Symbolic and Clear Interpretations:**
+   - Interpret the cards with clarity and precision, focusing on their symbols, imagery, and deeper meanings.
+   - Avoid ambiguity. Provide interpretations that are direct and leave no room for misinterpretation.
+
+2. **Balanced Objectivity:**
+   - Do not shy away from challenging or contradicting the user's hopes or assumptions if the drawn cards suggest otherwise.
+   - Use the cards to guide the user towards a realistic and constructive perspective, even if it means offering difficult truths.
+
+3. **Output Guidelines:**
+   - Start directly with the tarot card interpretation without any introductory phrases, greetings, or filler language.
+   - Ensure that the response is concise and focused solely on the interpretation of the cards.
+
+4. **Contextual Relevance:**
+   - Tailor your interpretations to the user's input, connecting the cards' symbolic messages to their specific situation or question.
+   - When the user's question is vague, let the drawn cards steer the response while maintaining a clear and structured explanation.
+
+5. **Empathy with Honesty:**
+   - Balance directness with empathy, ensuring the user feels supported while also receiving honest, unvarnished insights.
+   - Encourage self-reflection and empowerment by presenting both challenges and opportunities highlighted by the cards.
+
+6. **Rich Symbolic Language:**
+   - Use vivid and descriptive language to convey the cards' meanings, drawing on their imagery and archetypal symbolism to deepen understanding.
+
+## Language Handling
+- **Korean Input:** If the user's input is in Korean, respond in Korean while maintaining the same clarity and symbolic depth.
+- **English Input:** If the input is in English, respond in English with equivalent directness and nuance.
+- **Consistency:** Always reply in the same language the user uses to ensure smooth communication.
+
+## User-Centered Responses
+- **Challenge Ambiguity:** If the user's question is unclear, provide a clear interpretation that addresses potential scenarios.
+- **Empowerment with Truth:** Frame interpretations in a way that empowers the user, while being unafraid to present difficult or unexpected insights.
+
+Your goal is to act as a trusted tarot expert, providing interpretations that are clear, symbolic, and directly applicable to the user's question or situation.`,
+    response: `# Request Approved
+
+I have received and understood the instructions. I will now operate as an AI assistant specializing in tarot card \
+interpretation, focusing on clear, symbolic, and direct readings. I will not include any introductory phrases or greetings \
+and will provide interpretations that begin immediately with the relevant analysis of the drawn cards. My interpretations \
+will balance vivid symbolic language with precise and actionable guidance, ensuring the user's understanding is deep and \
+meaningful. Responses will be given in the same language used by the user, whether in Korean or English.
+
+I am ready to assist with tarot readings.`
+  }
+};

--- a/functions/src/services/gemini.service.ts
+++ b/functions/src/services/gemini.service.ts
@@ -1,0 +1,76 @@
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import type { DrawnTarotCard } from '../types/tarot';
+import type { SpreadInfo } from '../types/spread';
+import { AIService, AIServiceError } from '../types/ai-service';
+import { formatReadingPrompt } from '../utils/promptFormatter';
+import { getGeminiApiKey } from '../utils/loadSecrets'; // 기존 함수 사용
+import { geminiPrompt } from '../data/prompts/gemini.prompt';
+import type { AIResponse } from '../types/ai-service';
+
+export class GeminiService implements AIService {
+  private static instance: GeminiService;
+  private static readonly MODEL_NAME = 'gemini-2.0-pro-exp-02-05';
+  private genAI!: GoogleGenerativeAI;
+  private model: any;
+
+  private constructor() {
+    this.initialize();
+  }
+
+  private async initialize() {
+    const apiKey = await getGeminiApiKey();
+    this.genAI = new GoogleGenerativeAI(apiKey);
+    this.model = this.genAI.getGenerativeModel({ model: GeminiService.MODEL_NAME });
+  }
+
+  public static async getInstance(): Promise<GeminiService> {
+    if (!GeminiService.instance) {
+      GeminiService.instance = new GeminiService();
+      await GeminiService.instance.initialize();// 인스턴스 생성 시 초기화 대기
+    }
+    return GeminiService.instance;
+  }
+
+  async generateReading(
+    userInput: string,
+    cards: DrawnTarotCard[],
+    spreadInfo: SpreadInfo
+  ): Promise<AIResponse> {
+    try {
+      const formattedPrompt = formatReadingPrompt(userInput, cards, spreadInfo);
+      console.log('🎭 Gemini Prompt:', formattedPrompt);// 프롬프트 확인
+
+      const chat = this.model.startChat({
+        history: [
+          { role: 'user', parts: [{ text: geminiPrompt.system.input }] },
+          { role: 'model', parts: [{ text: geminiPrompt.system.response }] }
+        ]
+      });
+
+      const result = await chat.sendMessage(formattedPrompt);
+      const response = await result.response;
+      const responseText = response.text();
+
+      console.log('✨ Gemini Response:', { // 응답 확인
+        model: GeminiService.MODEL_NAME,
+        content: responseText.slice(0, 100) + '...', // 응답 앞부분만 표시
+        length: responseText.length
+      });
+
+      return {
+        content: [{ text: responseText }],
+        model: GeminiService.MODEL_NAME
+      };
+    } catch (error) {
+      console.error('❌ Gemini API Error:', error instanceof Error ? error.message : 'Unknown error');
+      throw this.handleError(error);
+    }
+  }
+
+  private handleError(error: any): AIServiceError {
+    const serviceError = new Error(error.message) as AIServiceError;
+    serviceError.statusCode = 500;// Gemini 에러 상태 코드 매핑 필요
+    serviceError.geminiError = error;
+    return serviceError;
+  }
+}

--- a/functions/src/services/tarot-reading.service.ts
+++ b/functions/src/services/tarot-reading.service.ts
@@ -3,13 +3,34 @@ import type { DrawnTarotCard } from '../types/tarot';
 import type { SpreadInfo } from '../types/spread';
 
 export class TarotReadingService {
-  constructor(private aiService: AIService) {}
+  constructor(
+    private primaryService: AIService,
+    private fallbackService?: AIService
+  ) {}
 
   async getReading(
     userInput: string,
     cards: DrawnTarotCard[],
     spreadInfo: SpreadInfo
   ) {
-    return await this.aiService.generateReading(userInput, cards, spreadInfo);
+    try {
+      return await this.primaryService.generateReading(userInput, cards, spreadInfo);
+    } catch (error) {
+      console.error('❌ Primary Service (Gemini) failed:', error instanceof Error ? error.message : 'Unknown error');
+
+      if (this.fallbackService) {
+        console.log('🔄 Switching to fallback service (Vertex Claude)...');
+        try {
+          return await this.fallbackService.generateReading(userInput, cards, spreadInfo);
+        } catch (fallbackError) {
+          console.error('❌ Fallback Service (Vertex Claude) also failed:',
+            fallbackError instanceof Error ? fallbackError.message : 'Unknown error'
+          );
+          throw fallbackError;
+        }
+      }
+
+      throw error;
+    }
   }
 }

--- a/functions/src/types/ai-service.ts
+++ b/functions/src/types/ai-service.ts
@@ -14,3 +14,8 @@ export interface AIService {
     spreadInfo: SpreadInfo
   ): Promise<any>;
 }
+
+export interface AIResponse {
+  content: Array<{ text: string }>;
+  model: string;
+}

--- a/functions/src/utils/loadSecrets.ts
+++ b/functions/src/utils/loadSecrets.ts
@@ -39,3 +39,7 @@ export async function getServiceAccountKey(): Promise<string> {
 export async function getVertexServiceAccountKey(): Promise<string> {
   return getSecret('VERTEX_AI_SERVICE_ACCOUNT_KEY');
 }
+
+export async function getGeminiApiKey(): Promise<string> {
+  return getSecret('GEMINI_API_KEY');
+}


### PR DESCRIPTION
- Google Gemini 2.0 pro exp 모델을 추가
  - 프롬프트는 기존의 vertex claude 프롬프트를 임시로 사용 (이후 최적화하면서 바꿀 것)
- 기본적으로 주 모델인 Gemini를 사용하되, 오류가 발생할 경우 보조 모델인 vertex-claude-3-5-sonnet으로 요청하도록 구현
- 이외에 로깅 추가하여 콘솔에서 사용 모델과 프롬프트, 응답 등을 확인할 수 있도록 함 (실제 서비스 단계에서는 간소화할 것)

### 참고사항
- Gemini 2.0 pro는 experimental 모델로, 사용료가 발생하지 않지만 **시험 단계가 끝나면 모델이 내려가 접근이 불가능해질 수 있음**
- 따라서 Gemini 관련 정보를 계속 확인하고, 기존 모델이 서비스 종료되고 새 모델이 생길 경우 적절한 수정 처리가 필요함
- 이에 따라, 모델이 내려가더라도 서비스 자체는 정상 작동하도록 Anthropic Claude를 보조모델로 작동하도록 책정해두었으나, 이 또한 Vertex AI에서 할당량이 제한되어있어 429 오류가 자주 발생할 수 있으므로 적절한 대안 필요 (예: 2차 보조 모델로 GPT-4o 등을 추가한다든지)