### PR TITLE
feat: 응답 구조화 지시와 정규식을 사용한 구조 적용

### DIFF
--- a/functions/src/data/prompts/gemini.prompt.ts
+++ b/functions/src/data/prompts/gemini.prompt.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 export interface GeminiPrompt {
   system: {
     input: string;
@@ -6,59 +5,4 @@ export interface GeminiPrompt {
   };
 }
 
-export const geminiPrompt: GeminiPrompt = {
-  system: {
-    input: `# System Setting
-
-You are now an AI assistant specializing in tarot card interpretation. Your role is to provide clear, direct, and symbolic tarot \
-readings based on user input and the cards drawn by the user. Below are the key instructions for your behavior:
-
-## Role
-- **Tarot Expert:** Your primary function is to interpret tarot cards, offering insightful and actionable interpretations based on \
-their symbolic meanings and the user's input.
-
-## Instructions
-1. **Symbolic and Clear Interpretations:**
-   - Interpret the cards with clarity and precision, focusing on their symbols, imagery, and deeper meanings.
-   - Avoid ambiguity. Provide interpretations that are direct and leave no room for misinterpretation.
-
-2. **Balanced Objectivity:**
-   - Do not shy away from challenging or contradicting the user's hopes or assumptions if the drawn cards suggest otherwise.
-   - Use the cards to guide the user towards a realistic and constructive perspective, even if it means offering difficult truths.
-
-3. **Output Guidelines:**
-   - Start directly with the tarot card interpretation without any introductory phrases, greetings, or filler language.
-   - Ensure that the response is concise and focused solely on the interpretation of the cards.
-
-4. **Contextual Relevance:**
-   - Tailor your interpretations to the user's input, connecting the cards' symbolic messages to their specific situation or question.
-   - When the user's question is vague, let the drawn cards steer the response while maintaining a clear and structured explanation.
-
-5. **Empathy with Honesty:**
-   - Balance directness with empathy, ensuring the user feels supported while also receiving honest, unvarnished insights.
-   - Encourage self-reflection and empowerment by presenting both challenges and opportunities highlighted by the cards.
-
-6. **Rich Symbolic Language:**
-   - Use vivid and descriptive language to convey the cards' meanings, drawing on their imagery and archetypal symbolism to deepen understanding.
-
-## Language Handling
-- **Korean Input:** If the user's input is in Korean, respond in Korean while maintaining the same clarity and symbolic depth.
-- **English Input:** If the input is in English, respond in English with equivalent directness and nuance.
-- **Consistency:** Always reply in the same language the user uses to ensure smooth communication.
-
-## User-Centered Responses
-- **Challenge Ambiguity:** If the user's question is unclear, provide a clear interpretation that addresses potential scenarios.
-- **Empowerment with Truth:** Frame interpretations in a way that empowers the user, while being unafraid to present difficult or unexpected insights.
-
-Your goal is to act as a trusted tarot expert, providing interpretations that are clear, symbolic, and directly applicable to the user's question or situation.`,
-    response: `# Request Approved
-
-I have received and understood the instructions. I will now operate as an AI assistant specializing in tarot card \
-interpretation, focusing on clear, symbolic, and direct readings. I will not include any introductory phrases or greetings \
-and will provide interpretations that begin immediately with the relevant analysis of the drawn cards. My interpretations \
-will balance vivid symbolic language with precise and actionable guidance, ensuring the user's understanding is deep and \
-meaningful. Responses will be given in the same language used by the user, whether in Korean or English.
-
-I am ready to assist with tarot readings.`
-  }
-};
+export { vertexClaudePrompt as geminiPrompt } from './vertex-claude.prompt';

--- a/functions/src/data/prompts/vertex-claude.prompt.ts
+++ b/functions/src/data/prompts/vertex-claude.prompt.ts
@@ -49,6 +49,16 @@ their symbolic meanings and the user's input.
 - **Challenge Ambiguity:** If the user's question is unclear, provide a clear interpretation that addresses potential scenarios.
 - **Empowerment with Truth:** Frame interpretations in a way that empowers the user, while being unafraid to present difficult or unexpected insights.
 
+## Output Format:
+- Your response must be structured with content first, followed by a title.
+- Wrap the main interpretation in <content></content> tags.
+- After the content, create a concise title summarizing the reading and wrap it in <title></title> tags.
+- The spelling and capitalization of the tags must exactly match the example: use lowercase "<content>" and "<title>".
+- Important: Always output the content first, then summarize it to create the title. Never write the title before the content.
+- Example format:
+  <content>Detailed tarot interpretation here...</content>
+  <title>Concise summary title of the reading</title>
+
 Your goal is to act as a trusted tarot expert, providing interpretations that are clear, symbolic, and directly applicable to the user's question or situation.`,
     response: `# Request Approved
 
@@ -57,6 +67,11 @@ interpretation, focusing on clear, symbolic, and direct readings. I will not inc
 and will provide interpretations that begin immediately with the relevant analysis of the drawn cards. My interpretations \
 will balance vivid symbolic language with precise and actionable guidance, ensuring the user's understanding is deep and \
 meaningful. Responses will be given in the same language used by the user, whether in Korean or English.
+
+I understand the required output format and will structure my responses as follows:
+1. First, I will provide the detailed tarot interpretation wrapped in <content></content> tags
+2. Then, I will create a concise title summarizing the reading and wrap it in <title></title> tags
+3. I will maintain the exact spelling and capitalization of these tags as shown in the example
 
 I am ready to assist with tarot readings.`,
   },

--- a/functions/src/routes/question-reading.routes.ts
+++ b/functions/src/routes/question-reading.routes.ts
@@ -15,6 +15,14 @@ router.post('/save', async (req: Request, res: Response): Promise<void> => {
       return;
     }
 
+    if (!interpretation.content || !interpretation.title) {
+      res.status(400).json({
+        error: 'Invalid interpretation format',
+        details: 'Interpretation must include content and title'
+      });
+      return;
+    }
+
     const readingId = await QuestionReadingRepositoryService.saveReading({
       question,
       cards,

--- a/functions/src/services/gemini.service.ts
+++ b/functions/src/services/gemini.service.ts
@@ -6,6 +6,7 @@ import { formatReadingPrompt } from '../utils/promptFormatter';
 import { getGeminiApiKey } from '../utils/loadSecrets'; // 기존 함수 사용
 import { geminiPrompt } from '../data/prompts/gemini.prompt';
 import type { AIResponse } from '../types/ai-service';
+import { parseAIResponse } from '../utils/response-parser';
 
 export class GeminiService implements AIService {
   private static instance: GeminiService;
@@ -57,9 +58,14 @@ export class GeminiService implements AIService {
         length: responseText.length
       });
 
+      const { content, title } = parseAIResponse(responseText);
+
       return {
-        content: [{ text: responseText }],
-        model: GeminiService.MODEL_NAME
+        content,
+        title,
+        model: GeminiService.MODEL_NAME,
+        rawResponse: responseText
+
       };
     } catch (error) {
       console.error('❌ Gemini API Error:', error instanceof Error ? error.message : 'Unknown error');

--- a/functions/src/services/vertex-claude.service.ts
+++ b/functions/src/services/vertex-claude.service.ts
@@ -6,6 +6,7 @@ import { formatReadingPrompt } from '../utils/promptFormatter';
 import type { DrawnTarotCard } from '../types/tarot';
 import type { SpreadInfo } from '../types/spread';
 import { AIService, AIServiceError, AIResponse } from '../types/ai-service';
+import { parseAIResponse } from '../utils/response-parser';
 
 export class VertexClaudeService implements AIService {
   private static instance: VertexClaudeService;
@@ -97,9 +98,14 @@ export class VertexClaudeService implements AIService {
         length: response.data.content[0].text.length
       });
 
+      const responseText = response.data.content[0].text;
+      const { content, title } = parseAIResponse(responseText);
+
       return {
-        content: response.data.content,
-        model: VertexClaudeService.MODEL_NAME
+        content,
+        title,
+        model: VertexClaudeService.MODEL_NAME,
+        rawResponse: responseText
       };
     } catch (error) {
       if (axios.isAxiosError(error)) {

--- a/functions/src/types/ai-service.ts
+++ b/functions/src/types/ai-service.ts
@@ -16,6 +16,8 @@ export interface AIService {
 }
 
 export interface AIResponse {
-  content: Array<{ text: string }>;
+  content: string;
+  title: string;
   model: string;
+  rawResponse?: string;
 }

--- a/functions/src/types/tarot.ts
+++ b/functions/src/types/tarot.ts
@@ -14,18 +14,18 @@ export interface DrawnTarotCard {
     description: string;
   }
 
-export interface TarotReading {
-  id: string;
-  question: string;
-  cards: DrawnTarotCard[];
-  interpretation: string;
-  createdAt: string;
-  spreadType: SpreadType;
-}
-
 export interface SaveTarotReadingRequest {
   question: string;
   cards: DrawnTarotCard[];
-  interpretation: string;
+  interpretation: {
+    content: string;
+    title: string;
+    model: string;
+  };
   spreadType: SpreadType;
+}
+
+export interface TarotReading extends SaveTarotReadingRequest {
+  id: string;
+  createdAt: string;
 }

--- a/functions/src/utils/response-parser.ts
+++ b/functions/src/utils/response-parser.ts
@@ -1,0 +1,13 @@
+// LLM 응답에서 content와 title을 추출하는 함수
+
+export function parseAIResponse(response: string): { content: string; title: string } {
+  // 정규식으로 content와 title 추출 (s 플래그 대신 [\s\S]* 사용)
+  const contentMatch = response.match(/<content>([\s\S]*?)<\/content>/);
+  const titleMatch = response.match(/<title>([\s\S]*?)<\/title>/);
+
+  // 기본값 설정 (파싱 실패 시)
+  const content = contentMatch ? contentMatch[1].trim() : response;
+  const title = titleMatch ? titleMatch[1].trim() : '타로 해석 결과';
+
+  return { content, title };
+}


### PR DESCRIPTION
- 기본 프롬프트에 출력 가이드라인을 추가함
  - 먼저 해석 결과를 <content></content>라는 형식의 태그 내에 출력하고,
  - 이 내용을 짧게 요약하여 <title></title> 태그 내에 출력하게끔 지시함
  - title이 먼저 오게 된다면, 글을 '이어 쓰는' LLM의 특성 상 이후에 작성되는 content가 영향을 받을 것이라 생각했음
  - 따라서 content => title 순으로 출력하도록 지시하고, 대소문자와 태그명을 예시와 정확히 일치하게 하라고 지시함
- parser 함수를 추가하여, <title> 태그와 <content>태그를 캐치해 분리하여 답변을 구조화된 객체로 바꿈
- 클라이언트는 이제 string 형태의 interpretation 대신 { title: string; content: string; model: string; } 와 같은 구조의 객체를 받게 되므로, DB 저장 요청 시에도 동일한 형태의 객체를 받아 저장하도록 수정함
- 단, 찐빠가 발생할 경우(=정규식으로 캐치하지 못하는 형태의 태그를 잘못 사용해서 출력하거나, 아예 태그를 사용하지 않는 등)에는
  1. 클라이언트로 잘못된 형태의 interpretation이 가게 되며
  2. 클라이언트는 이를 DB에 넘기려고 함
  3. (현재는 interpretation.content 혹은 title의 존재를 확인하여 interpretation이 올바른 형태인지 확인하도록 하나) 만약 이게 DB에 저장된다면
  4. result 혹은 share에서 잘못된 형태의 문서를 가져오려 하고, UI상으로 오류가 발생함
- 생각해볼 점: LLM이 발생시킬 수 있는 잘못된 출력의 모든 경우의 수를 다 고려하면서 로직을 짜야 하나?
  - 만약 그렇다면: 너무 낭비 아닌가? 얘가 그냥 '싫어'라고만 출력할지 어떻게 암? 아니면 아예 빈 답변을 출력하든가
  - 만약 아니라면: 그럼 LLM이 올바른 답변을 주는 데 실패하는 순간 UX가 완전히 엉망이 되어버리는데 그건 괜찮은거임?